### PR TITLE
Add xMore profile option

### DIFF
--- a/bungeecord/src/main/java/ch/andre601/advancedserverlist/bungeecord/events/PingEvent.java
+++ b/bungeecord/src/main/java/ch/andre601/advancedserverlist/bungeecord/events/PingEvent.java
@@ -78,8 +78,8 @@ public class PingEvent implements Listener{
         if(profile == null)
             return;
         
-        if(profile.isOneMore()){
-            max = online + 1;
+        if(profile.getXMore() >= 0){
+            max = online + profile.getXMore();
             ping.getPlayers().setMax(max);
         }
         
@@ -126,7 +126,6 @@ public class PingEvent implements Listener{
             
             if(playerInfos.length > 0)
                 ping.getPlayers().setSample(playerInfos);
-            
         }
         
         ping.setFavicon(ping.getFaviconObject());

--- a/core/src/main/java/ch/andre601/advancedserverlist/core/profiles/ServerListProfile.java
+++ b/core/src/main/java/ch/andre601/advancedserverlist/core/profiles/ServerListProfile.java
@@ -44,7 +44,7 @@ public class ServerListProfile{
     private final List<String> players;
     private final String playerCount;
     private final boolean hidePlayers;
-    private final boolean oneMore;
+    private final int xMore;
     
     public ServerListProfile(ConfigurationNode node, PluginLogger logger){
         this.priority = node.node("priority").getInt();
@@ -54,7 +54,7 @@ public class ServerListProfile{
         this.players = getList(node, "players", false);
         this.playerCount = node.node("playerCount").getString("");
         this.hidePlayers = node.node("hidePlayers").getBoolean();
-        this.oneMore = node.node("oneMore").getBoolean();
+        this.xMore = node.node("xMore").getInt(-1);
     }
     
     public int getPriority(){
@@ -77,8 +77,8 @@ public class ServerListProfile{
         return hidePlayers;
     }
     
-    public boolean isOneMore(){
-        return oneMore;
+    public int getXMore(){
+        return xMore;
     }
     
     public boolean evalConditions(Map<String, Object> replacements){

--- a/core/src/main/resources/profiles/default.yml
+++ b/core/src/main/resources/profiles/default.yml
@@ -60,11 +60,14 @@ players:
 playerCount: '<grey>Text'
 
 #
-# When set to true, will the ${server maxPlayers} placeholder display the online players + 1
-# This means that if 20 players are online, 21 would be displayed by the placeholder with this option enabled.
+# When set to 0 or higher will alter the max player count to the online count + xMore.
+# Example: With 20 online players would 'xMore: 1' show 20/21 and 'xMore: 0' show 20/20
 #
-# Note that the placeholder will not be affected in the conditions.
+# Note that this will also manipulate the ${server playersMax} placeholder when used
+# in motd, players or playerCount.
 #
-# Read more: https://github.com/Andre601/AdvancedServerList/wiki/Profile#onemore
+# Remove this option or set it to -1 to not alter the max player count.
 #
-oneMore: false
+# Read more: https://github.com/Andre601/AdvancedServerList/wiki/Profiles#xmore
+#
+xMore: -1

--- a/paper/src/main/java/ch/andre601/advancedserverlist/paper/events/PingEvent.java
+++ b/paper/src/main/java/ch/andre601/advancedserverlist/paper/events/PingEvent.java
@@ -74,8 +74,8 @@ public class PingEvent implements Listener{
         if(profile == null)
             return;
         
-        if(profile.isOneMore()){
-            max = online + 1;
+        if(profile.getXMore() >= 0){
+            max = online + profile.getXMore();
             event.setMaxPlayers(max);
         }
         

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         
-        <plugin.version>1.3.0</plugin.version>
+        <plugin.version>1.4.0</plugin.version>
         <plugin.description>Create multiple Server lists based on conditions.</plugin.description>
         
         <maven.compiler.source>16</maven.compiler.source>

--- a/spigot/src/main/java/ch/andre601/advancedserverlist/spigot/events/PingEvent.java
+++ b/spigot/src/main/java/ch/andre601/advancedserverlist/spigot/events/PingEvent.java
@@ -101,8 +101,8 @@ public class PingEvent implements Listener{
                 if(profile == null)
                     return;
                 
-                if(profile.isOneMore()){
-                    max = online + 1;
+                if(profile.getXMore() >= 0){
+                    max = online + profile.getXMore();
                     ping.setPlayersMaximum(max);
                 }
                 

--- a/velocity/src/main/java/ch/andre601/advancedserverlist/velocity/events/PingEvent.java
+++ b/velocity/src/main/java/ch/andre601/advancedserverlist/velocity/events/PingEvent.java
@@ -77,8 +77,8 @@ public class PingEvent{
         if(profile == null)
             return;
         
-        if(profile.isOneMore()){
-            max = online + 1;
+        if(profile.getXMore() >= 0){
+            max = online + profile.getXMore();
             builder.maximumPlayers(max);
         }
         


### PR DESCRIPTION
Originally made by @UsainSrht in #7 

Adds a `xMore` server list profile option.
When this option is set to any positive number - including 0 - will the Max player count be altered to display the current amount of online players + `xMore`