### PR TITLE
Create action for auto-publishing to Modrinth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,21 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        include:
+          - platforms: bungeecord,waterfall
+            directory: bungeecord
+            name: BungeeCord, Waterfall
+          - platforms: paper
+            directory: paper
+            name: Paper
+          - platforms: spigot
+            directory: spigot
+            name: Spigot
+          - platforms: velocity
+            directory: velocity
+            name: Velocity
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -16,8 +31,26 @@ jobs:
         java-version: '16'
     - name: Build jar
       run: mvn clean install
-    - name: Upload jar
-      uses: AButler/upload-release-assets@v2.0
+    - name: Obtain GitHub Release version
+      id: github-release
+      run: |
+        version=$(echo ${{ github.event.release.tag_name }} | cut -d'v' -f2)
+        echo "::set-output name=version::$version"
+    - name: Upload ${{ matrix.name }} to GitHub and Modrinth
+      uses: Kir-Antipov/mc-publish@v3.1
       with:
-        files: 'bungeecord/target/AdvancedServerList-*.jar;paper/target/AdvancedServerList-*.jar;spigot/target/AdvancedServerList-*.jar;velocity/target/AdvancedServerList-*.jar'
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        name: v${{ steps.github-release.outputs.version }} - ${{ matrix.name }}
+        version: ${{ steps.github-release.outputs.version }}
+        version-type: release
+        files: ${{ matrix.directory }}/target/AdvancedServerList-*.jar
+        files-secondary: ""
+        changelog: ${{ github.event.release.body }}
+        loaders: ${{ matrix.platforms }}
+        game-versions: |
+          1.19
+          1.19.1
+          1.19.2
+        java: 16
+        modrinth-id: xss83sOY
+        modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+        github-toke: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,6 @@ jobs:
         version-type: release
         files: ${{ matrix.directory }}/target/AdvancedServerList-*.jar
         files-secondary: ""
-        changelog: ${{ github.event.release.body }}
         loaders: ${{ matrix.platforms }}
         game-versions: |
           1.19

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,9 @@
-name: Build Jars
+#
+# Big thank you to @Kir-Antipov for providing this workflow file.
+# Check out his mc-publish action here: https://github.com/Kir-Antipov/mc-publish
+#
+
+name: Publish Assets
 
 on:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - platforms: bungeecord,waterfall
+          - platforms: |
+              bungeecord
+              waterfall
             directory: bungeecord
             name: BungeeCord, Waterfall
           - platforms: paper


### PR DESCRIPTION
Allows me to directly upload to Modrinth without the need to do it manually.

If everything is configured the right way should this action publish the generated jars alongside the changelog from the Release itself to Modrinth as I do right now manually.

Big thanks goes to @Kir-Antipov for providing me with a proper workflow file to use!