### PR TITLE
Add option to disable Cache

### DIFF
--- a/core/src/main/java/ch/andre601/advancedserverlist/core/file/FileHandler.java
+++ b/core/src/main/java/ch/andre601/advancedserverlist/core/file/FileHandler.java
@@ -156,4 +156,8 @@ public class FileHandler{
     public String getString(String def, Object... path){
         return node.node(path).getString(def);
     }
+    
+    public boolean getBoolean(Object... path){
+        return node.node(path).getBoolean();
+    }
 }

--- a/core/src/main/java/ch/andre601/advancedserverlist/core/profiles/players/PlayerHandler.java
+++ b/core/src/main/java/ch/andre601/advancedserverlist/core/profiles/players/PlayerHandler.java
@@ -53,6 +53,12 @@ public class PlayerHandler{
             core.getPlugin().getPluginLogger().info("No cache.data present. Skipping...");
             return;
         }
+        
+        if(core.getFileHandler().getBoolean("disable_cache")){
+            core.getPlugin().getPluginLogger().info("Cache disabled. Skipping player loading...");
+            return;
+        }
+        
         List<String> lines;
         try{
             lines = Files.readAllLines(cache);
@@ -85,6 +91,11 @@ public class PlayerHandler{
             core.getPlugin().getPluginLogger().info("No data to save. Skipping...");
             return;
         }
+    
+        if(core.getFileHandler().getBoolean("disable_cache")){
+            core.getPlugin().getPluginLogger().info("Cache disabled. Skipping player saving...");
+            return;
+        }
         
         StringJoiner joiner = new StringJoiner("\n");
         for(Map.Entry<String, String> entry : players){
@@ -104,13 +115,16 @@ public class PlayerHandler{
     }
     
     public void addPlayer(String name, String ip){
-        if(players.containsKey(name))
+        if(players.containsKey(name) || core.getFileHandler().getBoolean("disable_cache"))
             return;
         
         players.add(name, ip);
     }
     
     public String getPlayerByIp(String ip){
+        if(core.getFileHandler().getBoolean("disable_cache"))
+            core.getFileHandler().getString("Anonymous", "unknown_player");
+        
         for(Map.Entry<String, String> entry : players){
             if(entry.getValue().equals(ip))
                 return entry.getKey();

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -2,3 +2,11 @@
 # Used for when AdvancedServerList doesn't have a cached player to use for ${player name}
 #
 unknown_player: "Anonymous"
+
+#
+# Should the Caching of players be disabled?
+#
+# When set to true will AdvancedServerList not load any players from the cache.data file (if present) nor save any to it.
+# The ${player name} placeholder will also always return "Anonymous" in these cases, no matter if the player was cached or not before.
+#
+disable_cache: false


### PR DESCRIPTION
Adds a `disable_cache` option to the config.yml which allows to disable the caching of players into the `cache.data` file.
This also disables the saving of any cached player and also makes `${player name}` always return `Anonymous`