### PR TITLE
Add option to have multiple MOTDs.

### DIFF
--- a/core/src/main/java/ch/andre601/advancedserverlist/core/events/PingEventHandler.java
+++ b/core/src/main/java/ch/andre601/advancedserverlist/core/events/PingEventHandler.java
@@ -70,9 +70,9 @@ public class PingEventHandler{
         
         serverPlaceholders = new ServerPlaceholders(online, max, host);
         
-        if(!profile.getMotd().isEmpty()){
+        if(!profile.getMotds().isEmpty()){
             event.setMotd(
-                ComponentParser.list(profile.getMotd())
+                ComponentParser.text(profile.getMotd().getText())
                     .replacements(playerPlaceholders)
                     .replacements(serverPlaceholders)
                     .modifyText(text -> event.parsePAPIPlaceholders(text, player))

--- a/core/src/main/java/ch/andre601/advancedserverlist/core/events/PingEventHandler.java
+++ b/core/src/main/java/ch/andre601/advancedserverlist/core/events/PingEventHandler.java
@@ -70,23 +70,27 @@ public class PingEventHandler{
         
         serverPlaceholders = new ServerPlaceholders(online, max, host);
         
-        if(!profile.getMotds().isEmpty()){
-            event.setMotd(
-                ComponentParser.text(profile.getMotd().getText())
-                    .replacements(playerPlaceholders)
-                    .replacements(serverPlaceholders)
-                    .modifyText(text -> event.parsePAPIPlaceholders(text, player))
-                    .toComponent()
-            );
+        if(!profile.getMOTDs().isEmpty()){
+            ServerListProfile.Motd motd = profile.getRandomMOTD();
+            
+            if(motd != null){
+                event.setMotd(
+                    ComponentParser.text(motd.getText())
+                        .replacements(playerPlaceholders)
+                        .replacements(serverPlaceholders)
+                        .modifyText(text -> event.parsePAPIPlaceholders(text, player))
+                        .toComponent()
+                );
+            }
         }
         
-        if(profile.shouldHidePlayers()){
+        if(profile.isHidePlayersEnabled()){
             event.hidePlayers();
         }
         
-        if(!profile.getPlayerCount().isEmpty() && !profile.shouldHidePlayers()){
+        if(!profile.getPlayerCountText().isEmpty() && !profile.isHidePlayersEnabled()){
             event.setPlayerCount(
-                ComponentParser.text(profile.getPlayerCount())
+                ComponentParser.text(profile.getPlayerCountText())
                     .replacements(playerPlaceholders)
                     .replacements(serverPlaceholders)
                     .modifyText(text -> event.parsePAPIPlaceholders(text, player))
@@ -94,7 +98,7 @@ public class PingEventHandler{
             );
         }
         
-        if(!profile.getPlayers().isEmpty() && !profile.shouldHidePlayers()){
+        if(!profile.getPlayers().isEmpty() && !profile.isHidePlayersEnabled()){
             event.setPlayers(profile.getPlayers(), player, playerPlaceholders, serverPlaceholders);
         }
         

--- a/core/src/main/java/ch/andre601/advancedserverlist/core/file/FileHandler.java
+++ b/core/src/main/java/ch/andre601/advancedserverlist/core/file/FileHandler.java
@@ -127,7 +127,7 @@ public class FileHandler{
             if(tmp == null)
                 continue;
             
-            profiles.add(new ServerListProfile(tmp, logger));
+            profiles.add(ServerListProfile.Builder.resolve(tmp, logger).build());
             logger.info("Loaded " + file.getName());
         }
         

--- a/core/src/main/java/ch/andre601/advancedserverlist/core/profiles/ProfileManager.java
+++ b/core/src/main/java/ch/andre601/advancedserverlist/core/profiles/ProfileManager.java
@@ -52,10 +52,10 @@ public class ProfileManager{
     
     public ServerListProfile getProfile(){
         for(ServerListProfile profile : core.getFileHandler().getProfiles()){
-            if(profile.isInvalid())
+            if(profile.isInvalidProfile())
                 continue;
             
-            if(profile.evalConditions(replacements))
+            if(profile.evaluateConditions(replacements))
                 return profile;
         }
         

--- a/core/src/main/java/ch/andre601/advancedserverlist/core/profiles/ServerListProfile.java
+++ b/core/src/main/java/ch/andre601/advancedserverlist/core/profiles/ServerListProfile.java
@@ -37,7 +37,7 @@ public class ServerListProfile{
     private final int priority;
     private final List<Expression> expressions;
     
-    private final List<Motd> motds = new ArrayList<>();
+    private final List<Motd> motds;
     private final List<String> players;
     private final String playerCount;
     private final String favicon;
@@ -45,47 +45,47 @@ public class ServerListProfile{
     private final boolean extraPlayersEnabled;
     private final int extraPlayers;
     
-    private final Random motdRandom;
+    private final Random random = new Random();
     
-    public ServerListProfile(ConfigurationNode node, PluginLogger logger){
-        this.priority = node.node("priority").getInt();
-        this.expressions = createExpressions(getList(node, "conditions"), logger);
-        
-        loadMotds(node);
-        this.players = getList(node, "playerCount", "hover");
-        this.playerCount = node.node("playerCount", "text").getString("");
-        this.favicon = node.node("favicon").getString("");
-        this.hidePlayers = node.node("playerCount", "hidePlayers").getBoolean();
-        this.extraPlayersEnabled = node.node("playerCount", "extraPlayers", "enabled").getBoolean();
-        this.extraPlayers = node.node("playerCount", "extraPlayers", "amount").getInt();
-        
-        this.motdRandom = motds.size() <= 1 ? null : new Random();
+    public ServerListProfile(int priority, List<Expression> expressions, List<Motd> motds, List<String> players,
+                             String playerCount, String favicon, boolean hidePlayers, boolean extraPlayersEnabled,
+                             int extraPlayers){
+        this.priority = priority;
+        this.expressions = expressions;
+        this.motds = motds;
+        this.players = players;
+        this.playerCount = playerCount;
+        this.favicon = favicon;
+        this.hidePlayers = hidePlayers;
+        this.extraPlayersEnabled = extraPlayersEnabled;
+        this.extraPlayers = extraPlayers;
     }
     
     public int getPriority(){
         return priority;
     }
     
-    public Motd getMotd(){
-        if(motdRandom == null){
-            if(motds.isEmpty())
-                return null;
-            
-            return motds.get(0);
-        }
-        
-        return motds.get(motdRandom.nextInt(motds.size()));
+    public List<Motd> getMOTDs(){
+        return motds;
     }
     
-    public List<Motd> getMotds(){
-        return motds;
+    public Motd getRandomMOTD(){
+        if(motds.isEmpty())
+            return null;
+        
+        if(motds.size() == 1)
+            return motds.get(0);
+        
+        synchronized(random){
+            return motds.get(random.nextInt(motds.size()));
+        }
     }
     
     public List<String> getPlayers(){
         return players;
     }
     
-    public String getPlayerCount(){
+    public String getPlayerCountText(){
         return playerCount;
     }
     
@@ -93,7 +93,7 @@ public class ServerListProfile{
         return favicon;
     }
     
-    public boolean shouldHidePlayers(){
+    public boolean isHidePlayersEnabled(){
         return hidePlayers;
     }
     
@@ -105,82 +105,158 @@ public class ServerListProfile{
         return extraPlayers;
     }
     
-    public boolean evalConditions(Map<String, Object> replacements){
+    public boolean evaluateConditions(Map<String, Object> replacements){
         if(expressions.isEmpty())
             return true;
         
         for(Expression expression : expressions){
-            if(!expression.evaluate(replacements)){
+            if(!expression.evaluate(replacements))
                 return false;
-            }
         }
         
         return true;
     }
     
-    public boolean isInvalid(){
-        return getMotds().isEmpty() &&
+    /*
+     * Returns true if the Profile...
+     * ...doesn't have any valid MOTD set AND
+     * ...doesn't have any player hover set AND
+     * ...doesn't have a player count text set and hidePlayers is false AND
+     * ...doesn't have a favicon set.
+     */
+    public boolean isInvalidProfile(){
+        return getMOTDs().isEmpty() &&
             getPlayers().isEmpty() &&
-            (getPlayerCount().isEmpty() && !shouldHidePlayers()) &&
+            (getPlayerCountText().isEmpty() && !isHidePlayersEnabled()) &&
             getFavicon().isEmpty();
     }
     
-    private List<Expression> createExpressions(List<String> list, PluginLogger logger) {
-        if(list.isEmpty())
-            return Collections.emptyList();
+    public static class Builder{
         
-        List<Expression> expressions = new ArrayList<>();
-        for(String str : list){
-            Expression expression = new Expression(str);
-            
-            if(expression.getResult() != Expression.ExpressionResult.VALID){
-                logger.warn("Detected Invalid condition '%s'! Cause: %s", str, expression.getResult().getMessage());
-                continue;
-            }
-            
-            expressions.add(expression);
+        private final ConfigurationNode node;
+        
+        private final int priority;
+        private final PluginLogger logger;
+        
+        private final List<Expression> expressions = new ArrayList<>();
+        private final List<Motd> motds = new ArrayList<>();
+        private List<String> players = new ArrayList<>();
+        private String playerCount = null;
+        private String favicon = null;
+        private boolean hidePlayers = false;
+        private boolean extraPlayersEnabled = false;
+        private int extraPlayers = 0;
+        
+        private Builder(ConfigurationNode node, PluginLogger logger){
+            this.node = node;
+            this.priority = node.node("priority").getInt();
+            this.logger = logger;
         }
         
-        return expressions;
-    }
+        public static Builder resolve(ConfigurationNode node, PluginLogger logger){
+            return new Builder(node, logger)
+                .resolveExpressions()
+                .resolveMOTDs()
+                .resolvePlayers()
+                .resolvePlayerCount()
+                .resolveFavicon()
+                .resolveHidePlayers()
+                .resolveExtraPlayers()
+                .resolveExtraPlayersCount();
+        }
     
-    private void loadMotds(ConfigurationNode node){
-        List<String> temp = getList(node, "motds");
-        
-        if(!temp.isEmpty()){
-            for(String lines : temp){
-                Motd motd = Motd.resolve(lines);
-                if(motd == null)
-                    continue;
+        private Builder resolveExpressions(){
+            List<String> list = getList("conditions");
+            if(list.isEmpty())
+                return this;
+            
+            for(String str : list){
+                Expression expression = new Expression(str);
                 
-                motds.add(motd);
+                if(expression.getResult() != Expression.ExpressionResult.VALID){
+                    logger.warn("Detected invalid expression in condition '%s'! Reason: %s", str, expression.getResult().getMessage());
+                    continue;
+                }
+                
+                this.expressions.add(expression);
             }
-            return;
+            
+            return this;
         }
-        
-        temp = getList(node, "motd");
-        if(temp.isEmpty())
-            return;
-        
-        Motd motd = Motd.resolve(temp);
-        if(motd == null)
-            return;
-        
-        motds.add(motd);
-    }
     
-    private List<String> getList(ConfigurationNode node, Object... path){
-        List<String> list;
-        try{
-            list = node.node(path).getList(String.class);
-        }catch(SerializationException ex){
-            return Collections.emptyList();
+        private Builder resolveMOTDs(){
+            List<String> list = getList("motds");
+            if(!list.isEmpty()){
+                for(String lines : list){
+                    Motd motd = Motd.resolve(lines);
+                    if(motd == null)
+                        continue;
+                    
+                    this.motds.add(motd);
+                }
+                return this;
+            }
+            
+            list = getList("motd");
+            if(list.isEmpty())
+                return this;
+            
+            Motd motd = Motd.resolve(list);
+            if(motd == null)
+                return this;
+            
+            this.motds.add(motd);
+            return this;
+        }
+    
+        private Builder resolvePlayers(){
+            this.players = getList("playerCount", "hover");
+            return this;
+        }
+    
+        private Builder resolvePlayerCount(){
+            this.playerCount = node.node("playerCount", "text").getString("");
+            return this;
+        }
+    
+        private Builder resolveFavicon(){
+            this.favicon = node.node("favicon").getString("");
+            return this;
+        }
+    
+        private Builder resolveHidePlayers(){
+            this.hidePlayers = node.node("playerCount", "hidePlayers").getBoolean();
+            return this;
+        }
+    
+        private Builder resolveExtraPlayers(){
+            this.extraPlayersEnabled = node.node("playerCount", "extraPlayers", "enabled").getBoolean();
+            return this;
+        }
+    
+        private Builder resolveExtraPlayersCount(){
+            this.extraPlayers = node.node("playerCount", "extraPlayers", "amount").getInt();
+            return this;
+        }
+    
+        public ServerListProfile build(){
+            return new ServerListProfile(this.priority, this.expressions, this.motds, this.players, this.playerCount,
+                this.favicon, this.hidePlayers, this.extraPlayersEnabled, this.extraPlayers);
         }
         
-        if(list == null)
-            return Collections.emptyList();
-        
-        return list;
+        private List<String> getList(Object... path){
+            List<String> temp;
+            try{
+                temp = node.node(path).getList(String.class);
+            }catch(SerializationException ex){
+                temp = null;
+            }
+            
+            if(temp == null)
+                return Collections.emptyList();
+            
+            return temp;
+        }
     }
     
     public static class Motd{

--- a/core/src/main/resources/profiles/default.yml
+++ b/core/src/main/resources/profiles/default.yml
@@ -16,16 +16,17 @@ priority: 0
 #  - '{playerVersion} < 759'
 
 #
-# Set the MOTD that should be displayed.
+# Set the MOTDs that should be displayed.
 # Supports HEX colors for 1.16+ servers including gradients using MiniMessage's <gradient:color:color> format.
 # 
-# Remove this option or set it to motd: [] to not alter the MOTD.
+# Remove this option or set it to motds: [] to not alter the MOTD.
 #
-# Read more: https://github.com/Andre601/AdvancedServerList/wiki/Profiles#motd
+# Read more: https://github.com/Andre601/AdvancedServerList/wiki/Profiles#motds
 #
-motd:
-  - '<grey>Line 1'
-  - '<grey>Line 2'
+motds:
+  - |-
+    <grey>Line 1
+    <grey>Line 2
 
 #
 # Allows you to set a favicon for this server list profile.

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         
-        <plugin.version>1.8.1</plugin.version>
+        <plugin.version>1.9.0</plugin.version>
         <plugin.description>Create multiple Server lists based on conditions.</plugin.description>
         
         <maven.compiler.source>16</maven.compiler.source>


### PR DESCRIPTION
The server list profile will now have a `motds` option that allows to have multiple MOTDs being available.
The old `motd` option is still supported, but `motds` takes priority if present.

You have to use some YAML syntax stuff to make multiple lines possible. Example:
```yaml
motds:
  - |-
    Line 1
    Line 2
  - |- # This is another MOTD
    Line A
    Line B
```

This was suggested by CJYKK on my Discord server.