### PR TITLE
Plugin improvements

### DIFF
--- a/bukkit/src/main/java/ch/andre601/advancedserverlist/bukkit/BukkitCore.java
+++ b/bukkit/src/main/java/ch/andre601/advancedserverlist/bukkit/BukkitCore.java
@@ -23,38 +23,14 @@
  *
  */
 
-package ch.andre601.advancedserverlist.bukkit.events;
+package ch.andre601.advancedserverlist.bukkit;
 
-import ch.andre601.advancedserverlist.bukkit.BukkitCore;
 import ch.andre601.advancedserverlist.core.interfaces.core.PluginCore;
-import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.plugin.java.JavaPlugin;
 
-import java.net.InetSocketAddress;
-
-public class JoinEvent<F> implements Listener{
-    
-    private final BukkitCore<F> plugin;
-    
-    public JoinEvent(BukkitCore<F> plugin){
-        this.plugin = plugin;
-        Bukkit.getPluginManager().registerEvents(this, plugin);
-    }
-    
-    public static <F> void init(BukkitCore<F> plugin){
-        new JoinEvent<>(plugin);
-    }
-    
-    @EventHandler
-    public void onJoin(PlayerJoinEvent event){
-        InetSocketAddress address = event.getPlayer().getAddress();
-        if(address == null)
-            return;
-        
-        Player player = event.getPlayer();
-        plugin.getCore().getPlayerHandler().addPlayer(address.getHostString(), player.getName(), player.getUniqueId());
-    }
-}
+/* 
+ * Small convenience class to "merge" the PluginCore and JavaPlugin classes.
+ * Allows me to have BukkitCore<?> for whenever I also need a JavaPlugin (i.e. registering events).
+ * See JoinEvent class for an example.
+*/
+public abstract class BukkitCore<F> extends JavaPlugin implements PluginCore<F>{}

--- a/bukkit/src/main/java/ch/andre601/advancedserverlist/bukkit/objects/BukkitPlayerPlaceholders.java
+++ b/bukkit/src/main/java/ch/andre601/advancedserverlist/bukkit/objects/BukkitPlayerPlaceholders.java
@@ -32,8 +32,12 @@ import ch.andre601.advancedserverlist.spigot.objects.SpigotPlayer;
 
 public class BukkitPlayerPlaceholders extends PlaceholderProvider{
     
-    public BukkitPlayerPlaceholders(){
+    private BukkitPlayerPlaceholders(){
         super("player");
+    }
+    
+    public static BukkitPlayerPlaceholders init(){
+        return new BukkitPlayerPlaceholders();
     }
     
     @Override

--- a/bukkit/src/main/java/ch/andre601/advancedserverlist/bukkit/objects/PAPIPlaceholders.java
+++ b/bukkit/src/main/java/ch/andre601/advancedserverlist/bukkit/objects/PAPIPlaceholders.java
@@ -29,7 +29,6 @@ import ch.andre601.advancedserverlist.api.objects.GenericPlayer;
 import ch.andre601.advancedserverlist.api.objects.GenericServer;
 import ch.andre601.advancedserverlist.api.profiles.ProfileEntry;
 import ch.andre601.advancedserverlist.bukkit.BukkitCore;
-import ch.andre601.advancedserverlist.core.interfaces.core.PluginCore;
 import ch.andre601.advancedserverlist.core.objects.CachedPlayer;
 import ch.andre601.advancedserverlist.core.objects.GenericServerImpl;
 import ch.andre601.advancedserverlist.core.parsing.ComponentParser;
@@ -47,7 +46,7 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.net.InetSocketAddress;
-import java.util.Locale;
+import java.util.*;
 
 public class PAPIPlaceholders<F> extends PlaceholderExpansion{
     
@@ -107,25 +106,24 @@ public class PAPIPlaceholders<F> extends PlaceholderExpansion{
         GenericServer finalServer = new GenericServerImpl(online, max, host);
         
         return switch(identifier.toLowerCase(Locale.ROOT)){
-            case "motd" -> ComponentParser.list(entry.motd())
-                .modifyText(text -> PlaceholderAPI.setPlaceholders(pl, text))
-                .modifyText(text -> StringReplacer.replace(text, player, finalServer))
-                .toString();
-            case "favicon" -> ComponentParser.text(entry.favicon())
-                .modifyText(text -> PlaceholderAPI.setPlaceholders(pl, text))
-                .modifyText(text -> StringReplacer.replace(text, player, finalServer))
-                .toString();
-            case "playercount_hover" -> ComponentParser.list(entry.players())
-                .modifyText(text -> PlaceholderAPI.setPlaceholders(pl, text))
-                .modifyText(text -> StringReplacer.replace(text, player, finalServer))
-                .toString();
-            case "playercount_text" -> ComponentParser.text(entry.playerCountText())
-                .modifyText(text -> PlaceholderAPI.setPlaceholders(pl, text))
-                .modifyText(text -> StringReplacer.replace(text, player, finalServer))
-                .toString();
+            case "motd" -> getOption(entry.motd(), pl, player, finalServer);
+            case "favicon" -> getOption(entry.favicon(), pl, player, finalServer);
+            case "playercount_hover" -> getOption(entry.players(), pl, player, finalServer);
+            case "playercount_text" -> getOption(entry.playerCountText(), pl, player, finalServer);
             case "extra_players_max" -> String.valueOf(max);
             default -> null;
         };
+    }
+    
+    private String getOption(String str, Player pl, GenericPlayer player, GenericServer server){
+        return getOption(Collections.singletonList(str), pl, player, server);
+    }
+    
+    private String getOption(List<String> list, Player pl, GenericPlayer player, GenericServer server){
+        return ComponentParser.list(list)
+            .modifyText(text -> PlaceholderAPI.setPlaceholders(pl, text))
+            .modifyText(text -> StringReplacer.replace(text, player, server))
+            .toString();
     }
     
     private int resolveProtocol(Player player){

--- a/bukkit/src/main/java/ch/andre601/advancedserverlist/bukkit/objects/PAPIPlaceholders.java
+++ b/bukkit/src/main/java/ch/andre601/advancedserverlist/bukkit/objects/PAPIPlaceholders.java
@@ -28,6 +28,7 @@ package ch.andre601.advancedserverlist.bukkit.objects;
 import ch.andre601.advancedserverlist.api.objects.GenericPlayer;
 import ch.andre601.advancedserverlist.api.objects.GenericServer;
 import ch.andre601.advancedserverlist.api.profiles.ProfileEntry;
+import ch.andre601.advancedserverlist.bukkit.BukkitCore;
 import ch.andre601.advancedserverlist.core.interfaces.core.PluginCore;
 import ch.andre601.advancedserverlist.core.objects.CachedPlayer;
 import ch.andre601.advancedserverlist.core.objects.GenericServerImpl;
@@ -48,13 +49,17 @@ import org.jetbrains.annotations.NotNull;
 import java.net.InetSocketAddress;
 import java.util.Locale;
 
-public class PAPIPlaceholders extends PlaceholderExpansion{
+public class PAPIPlaceholders<F> extends PlaceholderExpansion{
     
-    private final PluginCore<?> plugin;
+    private final BukkitCore<F> plugin;
     
-    public PAPIPlaceholders(PluginCore<?> plugin){
+    private PAPIPlaceholders(BukkitCore<F> plugin){
         this.plugin = plugin;
         this.register();
+    }
+    
+    public static <F> PAPIPlaceholders<F> init(BukkitCore<F> plugin){
+        return new PAPIPlaceholders<>(plugin);
     }
     
     @Override
@@ -70,6 +75,11 @@ public class PAPIPlaceholders extends PlaceholderExpansion{
     @Override
     public @NotNull String getVersion(){
         return plugin.getCore().getVersion();
+    }
+    
+    @Override
+    public boolean persist(){
+        return true;
     }
     
     @Override

--- a/bukkit/src/main/java/ch/andre601/advancedserverlist/paper/PaperCore.java
+++ b/bukkit/src/main/java/ch/andre601/advancedserverlist/paper/PaperCore.java
@@ -25,6 +25,7 @@
 
 package ch.andre601.advancedserverlist.paper;
 
+import ch.andre601.advancedserverlist.bukkit.BukkitCore;
 import ch.andre601.advancedserverlist.bukkit.commands.CmdAdvancedServerList;
 import ch.andre601.advancedserverlist.bukkit.events.JoinEvent;
 import ch.andre601.advancedserverlist.bukkit.logging.BukkitLogger;
@@ -32,33 +33,37 @@ import ch.andre601.advancedserverlist.bukkit.objects.BukkitPlayerPlaceholders;
 import ch.andre601.advancedserverlist.bukkit.objects.PAPIPlaceholders;
 import ch.andre601.advancedserverlist.core.AdvancedServerList;
 import ch.andre601.advancedserverlist.core.interfaces.PluginLogger;
-import ch.andre601.advancedserverlist.core.interfaces.core.PluginCore;
 import ch.andre601.advancedserverlist.core.profiles.favicon.FaviconHandler;
 import ch.andre601.advancedserverlist.paper.events.PaperPingEvent;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.SimplePie;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.util.CachedServerIcon;
 
 import java.nio.file.Path;
 
-public class PaperCore extends JavaPlugin implements PluginCore<CachedServerIcon>{
+public class PaperCore extends BukkitCore<CachedServerIcon>{
     
     private final PluginLogger logger = new BukkitLogger(getLogger());
     
-    private AdvancedServerList core;
+    private AdvancedServerList<CachedServerIcon> core;
     private FaviconHandler<CachedServerIcon> faviconHandler;
+    private PAPIPlaceholders<CachedServerIcon> papiPlaceholders = null;
     
     @Override
     public void onEnable(){
-        this.core = new AdvancedServerList(this, new BukkitPlayerPlaceholders());
+        this.core = AdvancedServerList.init(this, BukkitPlayerPlaceholders.init());
         
         if(getServer().getPluginManager().isPluginEnabled("PlaceholderAPI"))
-            new PAPIPlaceholders(this);
+            papiPlaceholders = PAPIPlaceholders.init(this);
     }
     
     @Override
     public void onDisable(){
+        if(papiPlaceholders != null){
+            papiPlaceholders.unregister();
+            papiPlaceholders = null;
+        }
+        
         getCore().disable();
     }
     
@@ -93,7 +98,7 @@ public class PaperCore extends JavaPlugin implements PluginCore<CachedServerIcon
     }
     
     @Override
-    public AdvancedServerList getCore(){
+    public AdvancedServerList<CachedServerIcon> getCore(){
         return core;
     }
     

--- a/bukkit/src/main/java/ch/andre601/advancedserverlist/paper/events/PaperEventWrapper.java
+++ b/bukkit/src/main/java/ch/andre601/advancedserverlist/paper/events/PaperEventWrapper.java
@@ -28,9 +28,9 @@ package ch.andre601.advancedserverlist.paper.events;
 import ch.andre601.advancedserverlist.api.events.GenericServerListEvent;
 import ch.andre601.advancedserverlist.api.objects.GenericServer;
 import ch.andre601.advancedserverlist.api.profiles.ProfileEntry;
+import ch.andre601.advancedserverlist.bukkit.BukkitCore;
 import ch.andre601.advancedserverlist.bukkit.events.PreServerListSetEventImpl;
 import ch.andre601.advancedserverlist.bukkit.objects.SpigotPlayerImpl;
-import ch.andre601.advancedserverlist.core.interfaces.core.PluginCore;
 import ch.andre601.advancedserverlist.core.interfaces.events.GenericEventWrapper;
 import ch.andre601.advancedserverlist.core.objects.CachedPlayer;
 import ch.andre601.advancedserverlist.core.parsing.ComponentParser;
@@ -164,7 +164,7 @@ public class PaperEventWrapper implements GenericEventWrapper<CachedServerIcon, 
     }
     
     @Override
-    public PluginCore<CachedServerIcon> getPlugin(){
+    public BukkitCore<CachedServerIcon> getPlugin(){
         return plugin;
     }
     

--- a/bukkit/src/main/java/ch/andre601/advancedserverlist/spigot/SpigotCore.java
+++ b/bukkit/src/main/java/ch/andre601/advancedserverlist/spigot/SpigotCore.java
@@ -25,9 +25,11 @@
 
 package ch.andre601.advancedserverlist.spigot;
 
+import ch.andre601.advancedserverlist.bukkit.BukkitCore;
 import ch.andre601.advancedserverlist.bukkit.commands.CmdAdvancedServerList;
 import ch.andre601.advancedserverlist.bukkit.logging.BukkitLogger;
 import ch.andre601.advancedserverlist.bukkit.objects.BukkitPlayerPlaceholders;
+import ch.andre601.advancedserverlist.bukkit.objects.PAPIPlaceholders;
 import ch.andre601.advancedserverlist.core.AdvancedServerList;
 import ch.andre601.advancedserverlist.core.interfaces.PluginLogger;
 import ch.andre601.advancedserverlist.core.interfaces.core.PluginCore;
@@ -42,12 +44,13 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 import java.nio.file.Path;
 
-public class SpigotCore extends JavaPlugin implements PluginCore<WrappedServerPing.CompressedImage>{
+public class SpigotCore extends BukkitCore<WrappedServerPing.CompressedImage>{
     
     private final PluginLogger logger = new BukkitLogger(getLogger());
     
-    private AdvancedServerList core;
-    FaviconHandler<WrappedServerPing.CompressedImage> faviconHandler = null;
+    private AdvancedServerList<WrappedServerPing.CompressedImage> core;
+    private FaviconHandler<WrappedServerPing.CompressedImage> faviconHandler = null;
+    private PAPIPlaceholders<WrappedServerPing.CompressedImage> papiPlaceholders = null;
     
     @Override
     public void onEnable(){
@@ -64,11 +67,16 @@ public class SpigotCore extends JavaPlugin implements PluginCore<WrappedServerPi
             }catch(ClassNotFoundException ignored){}
         }
         
-        this.core = new AdvancedServerList(this, new BukkitPlayerPlaceholders());
+        this.core = AdvancedServerList.init(this, BukkitPlayerPlaceholders.init());
     }
     
     @Override
     public void onDisable(){
+        if(papiPlaceholders != null){
+            papiPlaceholders.unregister();
+            papiPlaceholders = null;
+        }
+        
         getCore().disable();
     }
     
@@ -103,7 +111,7 @@ public class SpigotCore extends JavaPlugin implements PluginCore<WrappedServerPi
     }
     
     @Override
-    public AdvancedServerList getCore(){
+    public AdvancedServerList<WrappedServerPing.CompressedImage> getCore(){
         return core;
     }
     
@@ -138,6 +146,10 @@ public class SpigotCore extends JavaPlugin implements PluginCore<WrappedServerPi
     @Override
     public String getLoader(){
         return "spigot";
+    }
+    
+    public void setPapiPlaceholders(PAPIPlaceholders<WrappedServerPing.CompressedImage> papiPlaceholders){
+        this.papiPlaceholders = papiPlaceholders;
     }
     
     private void printPaperInfo(){

--- a/bukkit/src/main/java/ch/andre601/advancedserverlist/spigot/SpigotCore.java
+++ b/bukkit/src/main/java/ch/andre601/advancedserverlist/spigot/SpigotCore.java
@@ -32,7 +32,6 @@ import ch.andre601.advancedserverlist.bukkit.objects.BukkitPlayerPlaceholders;
 import ch.andre601.advancedserverlist.bukkit.objects.PAPIPlaceholders;
 import ch.andre601.advancedserverlist.core.AdvancedServerList;
 import ch.andre601.advancedserverlist.core.interfaces.PluginLogger;
-import ch.andre601.advancedserverlist.core.interfaces.core.PluginCore;
 import ch.andre601.advancedserverlist.core.profiles.favicon.FaviconHandler;
 import ch.andre601.advancedserverlist.spigot.events.LoadEvent;
 import com.comphenix.protocol.wrappers.WrappedServerPing;
@@ -40,7 +39,6 @@ import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.SimplePie;
 import org.bukkit.command.PluginCommand;
-import org.bukkit.plugin.java.JavaPlugin;
 
 import java.nio.file.Path;
 
@@ -157,7 +155,7 @@ public class SpigotCore extends BukkitCore<WrappedServerPing.CompressedImage>{
         getPluginLogger().warn("You are using the Spigot version of AdvancedServerList on a Paper server.");
         getPluginLogger().warn("It is recommended to use the dedicated Paper version, to benefit from the");
         getPluginLogger().warn("following improvements:");
-        getPluginLogger().warn(" - No need to download external libraries already provided by PaperMC.");
+        getPluginLogger().warn(" - No downloading of external Libraries already provided by Paper (i.e. Adventure).");
         getPluginLogger().warn(" - No dependency on ProtocolLib thanks to provided Events.");
         getPluginLogger().warn("");
         getPluginLogger().warn("AdvancedServerList may work as normal, but consider using the PaperMC version instead!");

--- a/bukkit/src/main/java/ch/andre601/advancedserverlist/spigot/events/LoadEvent.java
+++ b/bukkit/src/main/java/ch/andre601/advancedserverlist/spigot/events/LoadEvent.java
@@ -54,10 +54,10 @@ public class LoadEvent implements Listener{
             return;
         }
         
-        manager.registerEvents(new JoinEvent(plugin), plugin);
-        manager.registerEvents(new ProtocolLibEvents(plugin, ProtocolLibrary.getProtocolManager()), plugin);
+        JoinEvent.init(plugin);
+        ProtocolLibEvents.init(plugin, ProtocolLibrary.getProtocolManager());
         
         if(manager.isPluginEnabled("PlaceholderAPI"))
-            new PAPIPlaceholders(plugin);
+            plugin.setPapiPlaceholders(PAPIPlaceholders.init(plugin));
     }
 }

--- a/bukkit/src/main/java/ch/andre601/advancedserverlist/spigot/events/ProtocolLibEventWrapper.java
+++ b/bukkit/src/main/java/ch/andre601/advancedserverlist/spigot/events/ProtocolLibEventWrapper.java
@@ -28,8 +28,8 @@ package ch.andre601.advancedserverlist.spigot.events;
 import ch.andre601.advancedserverlist.api.events.GenericServerListEvent;
 import ch.andre601.advancedserverlist.api.objects.GenericServer;
 import ch.andre601.advancedserverlist.api.profiles.ProfileEntry;
+import ch.andre601.advancedserverlist.bukkit.BukkitCore;
 import ch.andre601.advancedserverlist.bukkit.events.PreServerListSetEventImpl;
-import ch.andre601.advancedserverlist.core.interfaces.core.PluginCore;
 import ch.andre601.advancedserverlist.core.interfaces.events.GenericEventWrapper;
 import ch.andre601.advancedserverlist.core.objects.CachedPlayer;
 import ch.andre601.advancedserverlist.core.parsing.ComponentParser;
@@ -171,7 +171,7 @@ public class ProtocolLibEventWrapper implements GenericEventWrapper<WrappedServe
     }
     
     @Override
-    public PluginCore<WrappedServerPing.CompressedImage> getPlugin(){
+    public BukkitCore<WrappedServerPing.CompressedImage> getPlugin(){
         return plugin;
     }
     

--- a/bukkit/src/main/java/ch/andre601/advancedserverlist/spigot/events/ProtocolLibEvents.java
+++ b/bukkit/src/main/java/ch/andre601/advancedserverlist/spigot/events/ProtocolLibEvents.java
@@ -32,6 +32,7 @@ import com.comphenix.protocol.ProtocolManager;
 import com.comphenix.protocol.events.ListenerPriority;
 import com.comphenix.protocol.events.PacketAdapter;
 import com.comphenix.protocol.events.PacketEvent;
+import org.bukkit.Bukkit;
 import org.bukkit.event.Listener;
 
 import java.net.InetSocketAddress;
@@ -44,10 +45,15 @@ public class ProtocolLibEvents implements Listener{
     
     private static final Map<String, String> hostAddresses = new HashMap<>();
     
-    public ProtocolLibEvents(SpigotCore plugin, ProtocolManager protocolManager){
+    private ProtocolLibEvents(SpigotCore plugin, ProtocolManager protocolManager){
         this.protocolManager = protocolManager;
         
         loadPacketListener(plugin);
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+    
+    public static void init(SpigotCore plugin, ProtocolManager protocolManager){
+        new ProtocolLibEvents(plugin, protocolManager);
     }
     
     public static Map<String, String> getHostAddresses(){

--- a/bungeecord/src/main/java/ch/andre601/advancedserverlist/bungeecord/BungeeCordCore.java
+++ b/bungeecord/src/main/java/ch/andre601/advancedserverlist/bungeecord/BungeeCordCore.java
@@ -43,13 +43,13 @@ import java.nio.file.Path;
 
 public class BungeeCordCore extends Plugin implements PluginCore<Favicon>{
     
-    private AdvancedServerList core;
+    private AdvancedServerList<Favicon> core;
     private FaviconHandler<Favicon> faviconHandler = null;
     private final PluginLogger logger = new BungeeLogger(getLogger());
     
     @Override
     public void onEnable(){
-        this.core = new AdvancedServerList(this, new BungeePlayerPlaceholders());
+        this.core = AdvancedServerList.init(this, BungeePlayerPlaceholders.init());
     }
     
     @Override
@@ -85,7 +85,7 @@ public class BungeeCordCore extends Plugin implements PluginCore<Favicon>{
     }
     
     @Override
-    public AdvancedServerList getCore(){
+    public AdvancedServerList<Favicon> getCore(){
         return core;
     }
     

--- a/bungeecord/src/main/java/ch/andre601/advancedserverlist/bungeecord/objects/BungeePlayerPlaceholders.java
+++ b/bungeecord/src/main/java/ch/andre601/advancedserverlist/bungeecord/objects/BungeePlayerPlaceholders.java
@@ -33,8 +33,12 @@ import java.util.Locale;
 
 public class BungeePlayerPlaceholders extends PlaceholderProvider{
     
-    public BungeePlayerPlaceholders(){
+    private BungeePlayerPlaceholders(){
         super("player");
+    }
+    
+    public static BungeePlayerPlaceholders init(){
+        return new BungeePlayerPlaceholders();
     }
     
     @Override

--- a/core/src/main/java/ch/andre601/advancedserverlist/core/AdvancedServerList.java
+++ b/core/src/main/java/ch/andre601/advancedserverlist/core/AdvancedServerList.java
@@ -39,9 +39,9 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.Properties;
 
-public class AdvancedServerList{
+public class AdvancedServerList<F>{
     
-    private final PluginCore<?> plugin;
+    private final PluginCore<F> plugin;
     private final FileHandler fileHandler;
     private final CommandHandler commandHandler;
     private final PlayerHandler playerHandler;
@@ -51,19 +51,23 @@ public class AdvancedServerList{
     
     private String version;
     
-    public AdvancedServerList(PluginCore<?> plugin, PlaceholderProvider player){
+    private AdvancedServerList(PluginCore<F> plugin, PlaceholderProvider placeholders){
         this.plugin = plugin;
         this.fileHandler = new FileHandler(this);
         this.commandHandler = new CommandHandler(this);
         this.playerHandler = new PlayerHandler(this);
         
-        this.api.addPlaceholderProvider(player);
+        this.api.addPlaceholderProvider(placeholders);
         this.api.addPlaceholderProvider(new ServerPlaceholders());
         
         load();
     }
     
-    public PluginCore<?> getPlugin(){
+    public static <F> AdvancedServerList<F> init(PluginCore<F> plugin, PlaceholderProvider placeholders){
+        return new AdvancedServerList<>(plugin, placeholders);
+    }
+    
+    public PluginCore<F> getPlugin(){
         return plugin;
     }
     

--- a/velocity/src/main/java/ch/andre601/advancedserverlist/velocity/VelocityCore.java
+++ b/velocity/src/main/java/ch/andre601/advancedserverlist/velocity/VelocityCore.java
@@ -55,7 +55,7 @@ public class VelocityCore implements PluginCore<Favicon>{
     private final Path path;
     private final Metrics.Factory metrics;
     
-    private AdvancedServerList core;
+    private AdvancedServerList<Favicon> core;
     private FaviconHandler<Favicon> faviconHandler = null;
     
     @Inject
@@ -69,7 +69,7 @@ public class VelocityCore implements PluginCore<Favicon>{
     
     @Subscribe
     public void init(ProxyInitializeEvent event){
-        this.core = new AdvancedServerList(this, new VelocityPlayerPlaceholders());
+        this.core = AdvancedServerList.init(this, VelocityPlayerPlaceholders.init());
     }
     
     @Subscribe
@@ -109,7 +109,7 @@ public class VelocityCore implements PluginCore<Favicon>{
     }
     
     @Override
-    public AdvancedServerList getCore(){
+    public AdvancedServerList<Favicon> getCore(){
         return core;
     }
     

--- a/velocity/src/main/java/ch/andre601/advancedserverlist/velocity/objects/VelocityPlayerPlaceholders.java
+++ b/velocity/src/main/java/ch/andre601/advancedserverlist/velocity/objects/VelocityPlayerPlaceholders.java
@@ -31,8 +31,12 @@ import ch.andre601.advancedserverlist.api.objects.GenericServer;
 
 public class VelocityPlayerPlaceholders extends PlaceholderProvider{
     
-    public VelocityPlayerPlaceholders(){
+    private VelocityPlayerPlaceholders(){
         super("player");
+    }
+    
+    public static VelocityPlayerPlaceholders init(){
+        return new VelocityPlayerPlaceholders();
     }
     
     @Override


### PR DESCRIPTION
Some code improvements to the plugin, namely:

- Made a `BukkitCore<F>` class which extends the `JavaPlugin` class and implements the `PluginCore<F>` interface respectively.
  It allows a simpler way for me to provide both the PluginCore and JavaPlugin instances required.
- Make a static method for `AdvancedServerList` class initialization.
  This allows me to define a `<F>` for it to get rid of `PluginCore<?>`.
- Fix PlaceholderAPI Expansion not being persistent.
- Reduced duplicate code in PlaceholderAPI expansion by moving it to a dedicated method.
- Unregister PlaceholderAPI expansion during disabling (May help during reloads which I don't recommend).
- Fixed not registering the Join Event on the Bukkit variant.