### PR TITLE
Fix ProtocolLib component issue

### DIFF
--- a/bukkit/src/main/java/ch/andre601/advancedserverlist/spigot/events/ProtocolLibEventWrapper.java
+++ b/bukkit/src/main/java/ch/andre601/advancedserverlist/spigot/events/ProtocolLibEventWrapper.java
@@ -37,11 +37,12 @@ import ch.andre601.advancedserverlist.core.profiles.replacer.StringReplacer;
 import ch.andre601.advancedserverlist.spigot.SpigotCore;
 import ch.andre601.advancedserverlist.bukkit.objects.SpigotPlayerImpl;
 import com.comphenix.protocol.events.PacketEvent;
-import com.comphenix.protocol.wrappers.AdventureComponentConverter;
+import com.comphenix.protocol.wrappers.WrappedChatComponent;
 import com.comphenix.protocol.wrappers.WrappedGameProfile;
 import com.comphenix.protocol.wrappers.WrappedServerPing;
 import me.clip.placeholderapi.PlaceholderAPI;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 
@@ -77,7 +78,7 @@ public class ProtocolLibEventWrapper implements GenericEventWrapper<WrappedServe
     
     @Override
     public void setMotd(Component component){
-        ping.setMotD(AdventureComponentConverter.fromComponent(component));
+        ping.setMotD(WrappedChatComponent.fromJson(GsonComponentSerializer.gson().serialize(component)));
     }
     
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.commit/>
         
-        <plugin.version>3.0.1</plugin.version>
+        <plugin.version>3.0.2</plugin.version>
         <plugin.description>Create multiple Server lists based on conditions.</plugin.description>
         
         <api.version>v2.1.0</api.version>


### PR DESCRIPTION
Fixes #81 

Apparently is the `AdventureComponentConverter.fromComponent(Component)` method is only really usable within a Paper server due to it natively including the Adventure library.

I'm still not sure why the method worked in older versions. My best guess is, that I actually included the adventure lib inside the plugin before, so it was present and PL was able to hook into it...