### PR TITLE
Use new Paper plugin dependency structure

### DIFF
--- a/bukkit/src/main/resources/paper-plugin.yml
+++ b/bukkit/src/main/resources/paper-plugin.yml
@@ -9,18 +9,13 @@ loader: 'ch.andre601.advancedserverlist.paper.ASLLoader'
 api-version: 1.19
 
 dependencies:
-  - name: PlaceholderAPI
-    required: false
-    bootstrap: false
-  - name: ViaVersion
-    required: false
-    bootstrap: false
-
-load-after:
-  - name: PlaceholderAPI
-    bootstrap: false
-  - name: ViaVersion
-    bootstrap: false
+  server:
+    PlaceholderAPI:
+      load: BEFORE
+      required: false
+    ViaVersion:
+      load: BEFORE
+      required: false
 
 # The below stuff is NOT used by Paper plugin.
 commands:


### PR DESCRIPTION
Paper introduced a new, breaking change to their paper-plugin.yml structure.

The dependencies section is no longer a list/array, but rather has dedicated sections for `server` and `bootstrap` where you defined the plugin name, followed by options such as if it is required and when it should be loaded (before or after yours).

This removes the requirement of the `load-before` and `load-after` options as those are now part of the general dependency declaration.

This, unfortunately, will make my plugin incompatible with future versions starting at 1.21 because paper announced support for the old system until 1.21 comes out at which point it gets removed.

Because of this will I delay this PR merge until a first, stable 1.20 release comes out at which point I declare this plugin as 1.20+ only for the paper side moving forward.