### PR TITLE
Allow multiple servers/worlds for playersOnline, add whitelistEnabled for spigot/paper and config backup on migration.

### DIFF
--- a/bukkit/src/main/java/ch/andre601/advancedserverlist/bukkit/objects/placeholders/BukkitServerPlaceholders.java
+++ b/bukkit/src/main/java/ch/andre601/advancedserverlist/bukkit/objects/placeholders/BukkitServerPlaceholders.java
@@ -29,6 +29,7 @@ import ch.andre601.advancedserverlist.api.bukkit.objects.BukkitServer;
 import ch.andre601.advancedserverlist.api.PlaceholderProvider;
 import ch.andre601.advancedserverlist.api.objects.GenericPlayer;
 import ch.andre601.advancedserverlist.api.objects.GenericServer;
+import org.bukkit.Bukkit;
 import org.bukkit.World;
 
 public class BukkitServerPlaceholders extends PlaceholderProvider{
@@ -50,27 +51,38 @@ public class BukkitServerPlaceholders extends PlaceholderProvider{
         
         return switch(args[0]){
             case "playersOnline" -> {
-                if(args.length == 2){
-                    World world = bukkitServer.getWorlds().get(args[1]);
-                    if(world == null)
-                        yield null;
+                if(args.length >= 2){
+                    int players = 0;
+                    for(int i = 1; i < args.length; i++){
+                        World world = bukkitServer.getWorlds().get(args[i]);
+                        if(world == null)
+                            continue;
+                        
+                        players += world.getPlayers().size();
+                    }
                     
-                    yield String.valueOf(world.getPlayers().size());
+                    yield String.valueOf(players);
                 }
                 
                 yield String.valueOf(bukkitServer.getPlayersOnline());
             }
             case "playersMax" -> {
-                if(args.length == 2)
+                if(args.length >= 2)
                     yield null;
                 
                 yield String.valueOf(bukkitServer.getPlayersMax());
             }
             case "host" -> {
-                if(args.length == 2)
+                if(args.length >= 2)
                     yield null;
                 
                 yield bukkitServer.getHost();
+            }
+            case "whitelistEnabled" -> {
+                if(args.length >= 2)
+                    yield null;
+                
+                yield String.valueOf(Bukkit.isWhitelistEnforced());
             }
             default -> null;
         };

--- a/bukkit/src/main/java/ch/andre601/advancedserverlist/bukkit/objects/placeholders/BukkitServerPlaceholders.java
+++ b/bukkit/src/main/java/ch/andre601/advancedserverlist/bukkit/objects/placeholders/BukkitServerPlaceholders.java
@@ -82,7 +82,7 @@ public class BukkitServerPlaceholders extends PlaceholderProvider{
                 if(args.length >= 2)
                     yield null;
                 
-                yield String.valueOf(Bukkit.isWhitelistEnforced());
+                yield String.valueOf(Bukkit.hasWhitelist());
             }
             default -> null;
         };

--- a/bungeecord/src/main/java/ch/andre601/advancedserverlist/bungeecord/objects/BungeeServerPlaceholders.java
+++ b/bungeecord/src/main/java/ch/andre601/advancedserverlist/bungeecord/objects/BungeeServerPlaceholders.java
@@ -52,22 +52,33 @@ public class BungeeServerPlaceholders extends PlaceholderProvider{
         
         return switch(args[0]){
             case "playersOnline" -> {
-                if(args.length == 2){
-                    ServerInfo info = proxy.getServers().get(args[1]);
+                if(args.length >= 2){
+                    int players = 0;
                     
-                    yield String.valueOf(info.getPlayers().size());
+                    for(int i = 1; i < args.length; i++){
+                        ServerInfo info = proxy.getServers().get(args[i]);
+                        if(info == null)
+                            continue;
+                        
+                        players += info.getPlayers().size();
+                    }
+                    
+                    yield String.valueOf(players);
                 }
                 
                 yield String.valueOf(proxy.getPlayersOnline());
             }
             case "playersMax" -> {
                 // ServerInfo doesn't provide the max players that could join, so we won't allow an extra argument
-                if(args.length == 2)
+                if(args.length >= 2)
                     yield null;
                 
                 yield String.valueOf(proxy.getPlayersMax());
             }
             case "host" -> {
+                if(args.length > 2)
+                    yield null;
+                
                 if(args.length == 2){
                     ServerInfo info = proxy.getServers().get(args[1]);
                     

--- a/core/src/main/java/ch/andre601/advancedserverlist/core/file/FileHandler.java
+++ b/core/src/main/java/ch/andre601/advancedserverlist/core/file/FileHandler.java
@@ -40,6 +40,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -70,7 +73,7 @@ public class FileHandler{
     
     public boolean loadConfig(){
         logger.info("Loading config.yml...");
-        File folder = config.toFile().getParentFile();
+        File folder = plugin.getPlugin().getFolderPath().toFile();
         if(!folder.exists() && !folder.mkdirs()){
             logger.warn("Couldn't create folder for plugin. Is it missing Write permissions?");
             return false;
@@ -120,6 +123,9 @@ public class FileHandler{
             .path(config)
             .nodeStyle(NodeStyle.BLOCK)
             .build();
+        
+        if(!makeBackup())
+            return false;
         
         try{
             node = ConfigMigrator.updateNode(loader.load(), logger);
@@ -187,5 +193,33 @@ public class FileHandler{
     
     public boolean isOldConfig(){
         return node.node("configVersion").virtual() || node.node("configVersion").getInt(0) < ConfigMigrator.LATEST;
+    }
+    
+    private boolean makeBackup(){
+        logger.info("Making backup of old config.yml...");
+        
+        File backups = plugin.getPlugin().getFolderPath().resolve("backups").toFile();
+        if(!backups.exists() && !backups.mkdirs()){
+            logger.warn("Cannot create backups folder for migration!");
+            return false;
+        }
+        
+        String date = DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(Instant.now());
+        
+        File configBackup = new File(backups, "config_" + date.replace(":", "_") + ".yml");
+        try{
+            if(!configBackup.exists() && !configBackup.createNewFile()){
+                logger.warn("Cannot create backup file for config.yml!");
+                return false;
+            }
+            
+            Files.copy(config, configBackup.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            logger.info("Saved backup as '" + configBackup.getName() + "'!");
+            
+            return true;
+        }catch(IOException ex){
+            logger.warn("Encountered IOException while trying to create a backup.", ex);
+            return false;
+        }
     }
 }

--- a/core/src/main/java/ch/andre601/advancedserverlist/core/file/FileHandler.java
+++ b/core/src/main/java/ch/andre601/advancedserverlist/core/file/FileHandler.java
@@ -41,7 +41,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -204,7 +204,7 @@ public class FileHandler{
             return false;
         }
         
-        String date = DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(Instant.now());
+        String date = DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(LocalDateTime.now());
         
         File configBackup = new File(backups, "config_" + date.replace(":", "_") + ".yml");
         try{

--- a/docs/profiles/placeholders.md
+++ b/docs/profiles/placeholders.md
@@ -21,7 +21,9 @@ These placeholders use the player who pinged the server, to return values. They 
 | `${player isBanned}`        | Boolean for whether the player has been banned from the server. | Spigot/Paper | Yes                         |
 | `${player isWhitelisted}`   | Boolean for whether the player is whitelisted on the server.    | Spigot/Paper | Yes                         |
 
-[^1]: Whether this placeholder requires the player to have joined before while AdvancedServerList was running. When `disableCache` is enabled will these placeholders not work.
+[^1]:
+    Whether this placeholder requires the player to have joined before while AdvancedServerList was running.  
+    When `disableCache` is enabled will these placeholders not work.
 [^2]: Will default to whatever name has been provided in the `unknownPlayer -> name` option of the config.yml, when the player isn't cached yet.
 [^3]: Will default to whatever name has been provided in the `unknownPlayer -> uuid` option of the config.yml, when the player isn't cached yet.
 
@@ -36,12 +38,14 @@ These placeholders use values given by the server/proxy AdvancedServerList runs 
 | `${server host}`          | The domain/IP the player pinged.[^6]                       |
 
 [^4]:
-    An optional World (For Spigot/Paper) or Server (For BungeeCord/Velocity) can be provided to display the number of players online on said world/server.  
-    Full format is `${server playersOnline [world/server]}` (Replace `[world/server]` with a valid world or server name).
-[^5]: This placeholder is affected by the [`Amount` option](../#amount) in a server list profile, with the exception being when used in [`Conditions`](../#conditions).
+    An space-separated list of worlds (Spigot/Paper) or Servers (BungeeCord/Velocity) can be provided to display the number of players in these worlds/servers.  
+    Example: `${server playersOnline lobby1 lobby2}` will display the numbers of players online on the servers `lobby1` and `lobby2`.
+[^5]:
+    When the [`amount` option](../#amount) is used will this placeholder display the modified max players count.  
+    The only exception is [`conditions`](../#conditions) where it uses the actual max players of the server/proxy.
 [^6]:
     An optional server name can be provided to display the IP/Domain associated with that server. Only works on BungeeCord/Velocity.
-    Full format is `${server host [server]}` (Replace `[server]` with a valid server name).
+    Example: `${server host survival}` would display the IP/Domain associated with the `survival` server.
 
 ## PlaceholderAPI
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.commit/>
         
-        <plugin.version>3.1.0</plugin.version>
+        <plugin.version>3.2.0</plugin.version>
         <plugin.description>Create multiple Server lists based on conditions.</plugin.description>
         
         <api.version>v3.0.0</api.version>

--- a/velocity/src/main/java/ch/andre601/advancedserverlist/velocity/objects/VelocityServerPlaceholders.java
+++ b/velocity/src/main/java/ch/andre601/advancedserverlist/velocity/objects/VelocityServerPlaceholders.java
@@ -50,24 +50,32 @@ public class VelocityServerPlaceholders extends PlaceholderProvider{
         
         return switch(args[0]){
             case "playersOnline" -> {
-                if(args.length == 2){
-                    RegisteredServer info = proxy.getServers().get(args[1]);
-                    if(info == null)
-                        yield null;
+                if(args.length >= 2){
+                    int players = 0;
                     
-                    yield String.valueOf(info.getPlayersConnected().size());
+                    for(int i = 1; i < args.length; i++){
+                        RegisteredServer registeredServer = proxy.getServers().get(args[i]);
+                        if(registeredServer == null)
+                            continue;
+                        
+                        players += registeredServer.getPlayersConnected().size();
+                    }
+                    
+                    yield String.valueOf(players);
                 }
                 
                 yield String.valueOf(proxy.getPlayersOnline());
             }
             case "playersMax" -> {
-                if(args.length == 2){
+                if(args.length >= 2)
                     yield null;
-                }
                 
                 yield String.valueOf(proxy.getPlayersMax());
             }
             case "host" -> {
+                if(args.length > 2)
+                    yield null;
+                
                 if(args.length == 2){
                     RegisteredServer info = proxy.getServers().get(args[1]);
                     if(info == null)


### PR DESCRIPTION
Adds a new `whitelistEnabled` placeholder for server to return true/false based on if the whitelist is enabled on the server.

Additionally was playersOnline updated to allow multiple servers/worlds, to display their collective total.

Finally, a backup system was added to the config migrator. Should a migration happen would a backup of the config be made first.